### PR TITLE
Fix array comparison and paths

### DIFF
--- a/lib/loc_mods/cli.rb
+++ b/lib/loc_mods/cli.rb
@@ -67,7 +67,7 @@ module LocMods
       end
     end
 
-    def print_differences(differences, prefix = "", path = [])
+    def print_differences(differences, path = [])
       if differences.is_a?(Comparison)
         print_difference(differences, path)
         return
@@ -79,7 +79,7 @@ module LocMods
         current_path = path + [key]
         # This is a comparison
         if value.is_a?(Comparison)
-          print_difference(value, path)
+          print_difference(value, current_path)
           next
         end
 
@@ -105,7 +105,7 @@ module LocMods
           # puts "subvalue #{subvalue}, prefix #{prefix}, current_path + [subkey] #{current_path + [subkey]}"
 
           if subkey.is_a?(Integer)
-            print_differences(subvalue, prefix, current_path + [subkey])
+            print_differences(subvalue, current_path + [subkey])
           else
             if subvalue.is_a?(Comparison)
               print_difference(subvalue, current_path + [subkey])
@@ -122,8 +122,8 @@ module LocMods
       return unless value.original || value.updated
 
       puts "  #{format_path(current_path)}:"
-      puts "    Record 1: #{format_value(value.original)}"
-      puts "    Record 2: #{format_value(value.updated)}"
+      puts "    Record 1: #{format_value(value.original, '(no value)')}"
+      puts "    Record 2: #{format_value(value.updated, '(removed)')}"
       puts
     end
 
@@ -139,10 +139,10 @@ module LocMods
       end.join
     end
 
-    def format_value(value)
+    def format_value(value, nil_output = "(nil)")
       case value
       when nil, ComparableNil
-        "(nil)"
+        nil_output
       when String
         "\"#{value}\""
       else

--- a/lib/loc_mods/comparable_mapper.rb
+++ b/lib/loc_mods/comparable_mapper.rb
@@ -65,6 +65,10 @@ module LocMods
       when Array
         # puts "compare_values case 1"
         compare_arrays(self_value, other_value || [])
+      when NilClass, ComparableNil
+        unless [NilClass, ComparableNil].include?(other_value.class)
+          Comparison.new(original: self_value, updated: other_value.to_xml)
+        end
       when ComparableMapper
         # puts "compare_values case 2"
         self_value.compare(other_value)

--- a/spec/loc_mods/cli_spec.rb
+++ b/spec/loc_mods/cli_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'loc_mods/cli'
+
+RSpec.describe LocMods::Cli do
+  describe ".format_value" do
+    it "uses the nil output" do
+      result = subject.send(:format_value, nil, "test")
+
+      expect(result).to eq "test"
+    end
+  end
+end

--- a/spec/loc_mods/comparable_mapper_spec.rb
+++ b/spec/loc_mods/comparable_mapper_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "shale"
+
+class TestMapper < Shale::Mapper
+  include LocMods::ComparableMapper
+
+  attribute :value, Shale::Type::String
+end
+
+RSpec.describe LocMods::ComparableMapper do
+  describe ".compare" do
+    it "compares values" do
+      self_value = TestMapper.new(value: "to be removed")
+      other_value = TestMapper.new(value: nil)
+
+      result = self_value.compare(other_value)
+      expect(result).to include(:value)
+    end
+
+    it "compares nil object" do
+      self_value = LocMods::ComparableNil.new
+      other_value = TestMapper.new(value: "any value")
+
+      result = self_value.compare(other_value)
+      expect(result).to eq nil
+    end
+
+    it "compares nil value with nil object" do
+      self_value = TestMapper.new(value: nil)
+      other_value = LocMods::ComparableNil.new
+
+      result = self_value.compare(other_value)
+      expect(result).to eq nil
+    end
+
+    it "compares existing value with nil object" do
+      self_value = TestMapper.new(value: "any value")
+      other_value = LocMods::ComparableNil.new
+
+      result = self_value.compare(other_value)
+      expect(result).to include(:value)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #11 and #12

1. When a record is removed, the output will look like this:

```
Duplicate set #1 found for URL: https://doi.org/10.6028/NIST.IR.6659                                             
  Comparison 1:                                                                                                  
  File 1: project_files/bug1/removed/allrecords-MODS-991000009289708106.xml                                      
  File 2: project_files/bug1/removed/allrecords-MODS-991000179879708106.xml                                      
  ----                                                                                                           
  identifier[1].content:                                                                                         
    Record 1: "994303379"                               
    Record 2: (removed)                                 
                                                                                                                 
  identifier[1].type:                                   
    Record 1: "oclc"
    Record 2: (removed)
```

2. When a new record is added, the output will look like this:

```
  subject[0]:                                                                                                    
    Record 1: (no value)                                                                                         
    Record 2: "<subject authority="lcsh"><topic>COVID-19 Pandemic, 2020-</topic></subject>"                      
                                                                                                                 
  subject[1]:                                                                                                    
    Record 1: (no value)                                                                                         
    Record 2: "<subject><topic>Community resilience</topic></subject>"                                           
                                                                                                                 
  subject._array_size_difference:                       
    Record 1: 0                                                                                                  
    Record 2: 2      
```

3. When records are different, the path will be displayed properly:

```
Duplicate set #1 found for URL: https://doi.org/10.6028/NIST.IR.6659                                             
  Comparison 1:                                                                                                  
  File 1: project_files/bug1/paths/allrecords-MODS-991000009289708106.xml
  File 2: project_files/bug1/paths/allrecords-MODS-991000179879708106.xml                                        
  ----                                                  
  identifier[1].content:                                                                                         
    Record 1: "994303379"                               
    Record 2: (removed)                                                                                          
                                                        
  identifier[1].type:                                                                                            
    Record 1: "oclc"                                                                                             
    Record 2: (removed)                                                                                          
                                                        
  identifier._array_size_difference:
    Record 1: 2
    Record 2: 1
```